### PR TITLE
Add CFE Lite inbound video call diagrams

### DIFF
--- a/src/generate_cfe_lite_inbound_video_component.py
+++ b/src/generate_cfe_lite_inbound_video_component.py
@@ -1,0 +1,33 @@
+import argparse
+from diagrams import Diagram, Cluster
+from diagrams.custom import Custom
+
+# Setting up the argument parser to accept an output format argument
+parser = argparse.ArgumentParser(description="Generate a diagram for CFE Lite inbound SIP video architecture with a specified output format.")
+parser.add_argument('--format', type=str, default='png', help='Output format of the diagram (e.g., png, jpg, svg)')
+args = parser.parse_args()
+
+# Creating the diagram with the specified output format
+with Diagram(
+    "CFE Lite Inbound SIP Video Architecture",
+    show=False,
+    direction="LR",
+    outformat=args.format,
+    filename="diagrams/cfe_lite_inbound_video_component",
+):
+    vonage = Custom("Vonage SIP\nInterconnect", "../assets/icons/placeholder.png")  # Placeholder icon
+    cfe_lite = Custom("CFE Lite\nMicroservice", "../assets/icons/microservices.png")
+    with Cluster("XMS Cluster (MRB)"):
+        mrb = Custom("MRB", "../assets/icons/placeholder.png")  # Placeholder icon
+        xms_nodes = [
+            Custom("XMS 1", "../assets/icons/placeholder.png"),  # Placeholder icon
+            Custom("XMS 2", "../assets/icons/placeholder.png"),  # Placeholder icon
+        ]
+        mrb >> xms_nodes
+    twilio = Custom("Twilio APIs", "../assets/icons/api.png")
+    interpreter = Custom("Interpreter", "../assets/icons/interpreter.png")
+
+    vonage >> cfe_lite >> mrb
+    for xms in xms_nodes:
+        xms >> interpreter
+    cfe_lite >> twilio >> interpreter

--- a/src/generate_cfe_lite_inbound_video_sequence_diagram.py
+++ b/src/generate_cfe_lite_inbound_video_sequence_diagram.py
@@ -1,0 +1,50 @@
+import os
+
+# Define the diagram in Mermaid syntax with adjusted font sizes and styles
+sequence_diagram = """
+%%{init: {'theme': 'default', 'themeVariables': {
+    'fontSize': '16px',
+    'fontFamily': 'Arial',
+    'sequenceNumberColor': '#000000',
+    'actorFontSize': '16px',
+    'actorFontFamily': 'Arial',
+    'messageFontSize': '14px',
+    'messageFontFamily': 'Arial'
+}}}%%
+sequenceDiagram
+    participant Vonage
+    participant CFE_Lite as CFE Lite
+    participant MRB
+    participant XMS
+    participant Twilio
+    participant Interpreter
+
+    Vonage->>CFE_Lite: SIP INVITE
+    CFE_Lite->>MRB: Allocate media server
+    MRB->>XMS: Select XMS node
+    CFE_Lite-->>Vonage: 200 OK
+    CFE_Lite->>Twilio: Request interpreter
+    Twilio-->>CFE_Lite: Interpreter selected
+    CFE_Lite->>XMS: Dial interpreter
+    XMS->>Interpreter: Connect call
+    Interpreter-->>XMS: Answer
+    XMS-->>CFE_Lite: Media session established
+    CFE_Lite-->>Twilio: Status callbacks
+"""
+
+os.makedirs('diagrams', exist_ok=True)
+
+diagram_file = 'diagrams/cfe_lite_inbound_video_sequence_diagram.mmd'
+with open(diagram_file, 'w') as f:
+    f.write(sequence_diagram)
+
+svg_output = 'diagrams/cfe_lite_inbound_video_sequence_diagram.svg'
+png_output = 'diagrams/cfe_lite_inbound_video_sequence_diagram.png'
+
+svg_command = f'mmdc -i {diagram_file} -o {svg_output} -t default'
+png_command = f'mmdc -i {diagram_file} -o {png_output} -t default --scale 4'
+
+os.system(svg_command)
+os.system(png_command)
+
+os.remove(diagram_file)


### PR DESCRIPTION
## Summary
- Add component diagram script for the CFE Lite inbound SIP video architecture
- Add Mermaid sequence diagram script for the inbound video call flow

## Testing
- `python src/generate_cfe_lite_inbound_video_component.py`
- `python src/generate_cfe_lite_inbound_video_sequence_diagram.py` *(fails: libatk-1.0.so.0 missing)*
- `sudo apt-get update` *(fails: repository ... no longer signed)*

------
https://chatgpt.com/codex/tasks/task_b_68ac68e2c06c832ab09a3b1bfd8b9c47