### PR TITLE
Replace Twilio with Propio Hydration API in CFE Lite diagrams

### DIFF
--- a/src/generate_cfe_lite_inbound_video_component.py
+++ b/src/generate_cfe_lite_inbound_video_component.py
@@ -24,10 +24,10 @@ with Diagram(
             Custom("XMS 2", "../assets/icons/xms.png"),
         ]
         mrb >> xms_nodes
-    twilio = Custom("Twilio APIs", "../assets/icons/api.png")
+    hydration_api = Custom("Propio Hydration API", "../assets/icons/api.png")
     interpreter = Custom("Interpreter", "../assets/icons/interpreter.png")
 
     vonage >> cfe_lite >> mrb
     for xms in xms_nodes:
         xms >> interpreter
-    cfe_lite >> twilio >> interpreter
+    cfe_lite >> hydration_api >> interpreter

--- a/src/generate_cfe_lite_inbound_video_sequence_diagram.py
+++ b/src/generate_cfe_lite_inbound_video_sequence_diagram.py
@@ -16,20 +16,20 @@ sequenceDiagram
     participant CFE_Lite as CFE Lite
     participant MRB
     participant XMS
-    participant Twilio
+    participant Hydration_API as Propio Hydration API
     participant Interpreter
 
     Vonage->>CFE_Lite: SIP INVITE
     CFE_Lite->>MRB: Allocate media server
     MRB->>XMS: Select XMS node
     CFE_Lite-->>Vonage: 200 OK
-    CFE_Lite->>Twilio: Request interpreter
-    Twilio-->>CFE_Lite: Interpreter selected
+    CFE_Lite->>Hydration_API: Request interpreter
+    Hydration_API-->>CFE_Lite: Interpreter selected
     CFE_Lite->>XMS: Dial interpreter
     XMS->>Interpreter: Connect call
     Interpreter-->>XMS: Answer
     XMS-->>CFE_Lite: Media session established
-    CFE_Lite-->>Twilio: Status callbacks
+    CFE_Lite-->>Hydration_API: Status callbacks
 """
 
 os.makedirs('diagrams', exist_ok=True)


### PR DESCRIPTION
## Summary
- replace Twilio node with Propio Hydration API in CFE Lite inbound video component diagram
- update sequence diagram to call Propio Hydration API instead of Twilio

## Testing
- `python -m py_compile src/generate_cfe_lite_inbound_video_component.py src/generate_cfe_lite_inbound_video_sequence_diagram.py`
- `python src/generate_cfe_lite_inbound_video_component.py --format png` *(fails: ModuleNotFoundError: No module named 'diagrams')*
- `python src/generate_cfe_lite_inbound_video_sequence_diagram.py` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_b_68acc0e0ea0c832a904e58a2b9785850