### PR TITLE
Refine CFE Lite sequence diagram with acknowledgments

### DIFF
--- a/src/generate_cfe_lite_inbound_video_sequence_diagram.py
+++ b/src/generate_cfe_lite_inbound_video_sequence_diagram.py
@@ -21,15 +21,24 @@ sequenceDiagram
 
     Vonage->>CFE_Lite: SIP INVITE
     CFE_Lite->>MRB: Allocate media server
-    MRB->>XMS: Select XMS node
+    MRB-->>CFE_Lite: XMS node chosen
     CFE_Lite-->>Vonage: 200 OK
     CFE_Lite->>Hydration_API: Request interpreter
     Hydration_API-->>CFE_Lite: Interpreter selected
     CFE_Lite->>XMS: Dial interpreter
+    XMS-->>CFE_Lite: Ringing
     XMS->>Interpreter: Connect call
-    Interpreter-->>XMS: Answer
-    XMS-->>CFE_Lite: Media session established
-    CFE_Lite-->>Hydration_API: Status callbacks
+    alt Interpreter answers
+        Interpreter-->>XMS: Answer
+        XMS-->>CFE_Lite: Answer
+        XMS-->>CFE_Lite: Media session established
+    else Call failed
+        XMS-->>CFE_Lite: Failure
+    end
+    loop Status updates
+        XMS-->>CFE_Lite: Status update
+        CFE_Lite-->>Hydration_API: Status callbacks
+    end
 """
 
 os.makedirs('diagrams', exist_ok=True)


### PR DESCRIPTION
## Summary
- Model MRB acknowledging CFE Lite with the selected XMS node
- Show XMS async events (ringing, answer/failure) and media session establishment
- Loop ongoing status updates from XMS back through CFE Lite to Propio Hydration API

## Testing
- `python src/generate_cfe_lite_inbound_video_sequence_diagram.py` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_b_68aee9da7298832ab90523a42230ffc6