### PR TITLE
Connect users to Vonage in CFE Lite inbound video diagram

### DIFF
--- a/src/generate_cfe_lite_inbound_video_component.py
+++ b/src/generate_cfe_lite_inbound_video_component.py
@@ -15,6 +15,7 @@ with Diagram(
     outformat=args.format,
     filename="diagrams/cfe_lite_inbound_video_component",
 ):
+    users = Custom("Users", "../assets/icons/users.png")
     vonage = Custom("Vonage SIP\nInterconnect", "../assets/icons/vonage.png")
     cfe_lite = Custom("CFE Lite\nMicroservice", "../assets/icons/microservices.png")
     with Cluster("XMS Cluster (MRB)"):
@@ -27,7 +28,7 @@ with Diagram(
     hydration_api = Custom("Propio Hydration API", "../assets/icons/api.png")
     interpreter = Custom("Interpreter", "../assets/icons/interpreter.png")
 
-    vonage >> cfe_lite >> mrb
+    users >> vonage >> cfe_lite >> mrb
     for xms in xms_nodes:
         xms >> interpreter
     cfe_lite >> hydration_api >> interpreter


### PR DESCRIPTION
## Summary
- Add Users node to CFE Lite inbound video diagram and connect it to Vonage

## Testing
- `python src/generate_cfe_lite_inbound_video_component.py --format png`


------
https://chatgpt.com/codex/tasks/task_b_68b7ab6dfbfc832aa6b84dc50e63e683